### PR TITLE
两处改动

### DIFF
--- a/google-font-fix-options.php
+++ b/google-font-fix-options.php
@@ -30,7 +30,7 @@ $gravatar_service   = get_option('gravatar_service');
  * Assignments are for default value - change on admin page.
  */
 $gff_options = array(
-    'google_service'    => !empty($google_service) ? $google_service : 'proxy.ustclug.org',
+    'google_service'    => !empty($google_service) ? $google_service : 'cat.net',
     'gravatar_service'  => !empty($gravatar_service) ? $gravatar_service : 'https://secure.gravatar.com/avatar',
 );
 

--- a/google-font-fix-options.php
+++ b/google-font-fix-options.php
@@ -30,7 +30,7 @@ $gravatar_service   = get_option('gravatar_service');
  * Assignments are for default value - change on admin page.
  */
 $gff_options = array(
-    'google_service'    => !empty($google_service) ? $google_service : 'lug.ustc.edu.cn',
+    'google_service'    => !empty($google_service) ? $google_service : 'proxy.ustclug.org',
     'gravatar_service'  => !empty($gravatar_service) ? $gravatar_service : 'https://secure.gravatar.com/avatar',
 );
 
@@ -65,8 +65,8 @@ function gff_option_page() {
                     <?php if ( !is_ssl() ): ?>
                         <option value="useso.com"><?php echo __('Qihoo 360 Technology Co. Ltd.', 'google-font-fix'); ?></option>
                     <?php endif; ?>
-                        <option value="lug.ustc.edu.cn"><?php echo __('University of Science and Technology of China', 'google-font-fix'); ?></option>
-                        <option value="css.network"><?php echo __('CSS.NET', 'google-font-fix'); ?></option>
+                        <option value="proxy.ustclug.org"><?php echo __('University of Science and Technology of China', 'google-font-fix'); ?></option>
+                        <option value="cat.net"><?php echo __('CSS.NET', 'google-font-fix'); ?></option>
                     </select>
                 </td>
             </tr>

--- a/google-font-fix.php
+++ b/google-font-fix.php
@@ -14,7 +14,12 @@ require_once(GFF_PLUGIN_PATH . 'geo/geoip.inc.php');
 require_once(GFF_PLUGIN_PATH . 'google-font-fix-options.php');
 
 function google_apis_fix($buffer) {
-    $country_code = gff_get_country_code($_SERVER['REMOTE_ADDR']);
+    $remote_addr = $_SERVER['REMOTE_ADDR'];
+    //ipv6 user should have direct access to GoogleAPIs
+    if ( strpos($remote_addr, ':') ) {
+        return $buffer;
+    }
+    $country_code = gff_get_country_code($remote_addr);
     if ( $country_code != 'CN' ) {
         return $buffer;
     }

--- a/google-font-fix.php
+++ b/google-font-fix.php
@@ -14,12 +14,7 @@ require_once(GFF_PLUGIN_PATH . 'geo/geoip.inc.php');
 require_once(GFF_PLUGIN_PATH . 'google-font-fix-options.php');
 
 function google_apis_fix($buffer) {
-    $remote_addr = $_SERVER['REMOTE_ADDR'];
-    //ipv6 user should have direct access to GoogleAPIs
-    if ( strpos($remote_addr, ':') ) {
-        return $buffer;
-    }
-    $country_code = gff_get_country_code($remote_addr);
+    $country_code = gff_get_country_code($_SERVER['REMOTE_ADDR']);
     if ( $country_code != 'CN' ) {
         return $buffer;
     }


### PR DESCRIPTION
- IPv6用户不应该替换google服务，既然IPv6，理应拥有直连能力  
- ustc和css.network都更换了域名，更新一下，减少一个302的访问  

另外，其实建议把ustc的默认值下掉，ustc的ajax（公共lib服务）完全不工作，卡loading数十秒之后302回google，这可都是同步script，你一个页面先卡半分钟，然后302再来个google卡300s连接超时，访客早关页面了